### PR TITLE
fix: update release branch from "main" to "master" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "release": {
     "branches": [
-      "main"
+      "master"
     ]
   }
 }


### PR DESCRIPTION
This pull request updates the release configuration in `package.json` to use the `master` branch instead of `main` for release workflows.

- Release configuration: Changed the release branch from `main` to `master` in `package.json`.